### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,5 +83,5 @@ end
 gem 'bullet', group: 'development'
 
 group :development, :test do
-  gem "database_cleaner"
+  gem 'database_cleaner'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,9 @@ group :development, :test do
   gem 'rspec-rails', '>= 3.9.0'
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.1'
 end
+
+gem 'bullet', group: 'development'
+
+group :development, :test do
+  gem "database_cleaner"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.4)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.38.0)
       addressable
       matrix
@@ -84,6 +87,12 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     debug (1.7.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -229,6 +238,7 @@ GEM
     tzinfo-data (1.2022.7)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.3.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -251,7 +261,9 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
+  database_cleaner
   debug
   importmap-rails
   jbuilder

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
 <%@post.each_with_index do |pt,index|%>
 <%= render 'posts/post', post:pt, index:index, user:@user.id %>
 <div class="border margin">
-<%pt.five_recent_comments.each do |comment|%>
+<%pt.five_recent_comments.includes([:author]).each do |comment|%>
 <%= render 'posts/comment', comment:comment %>
 <%end%>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="border">
-        <% @post.comments.each do |comment| %>
+        <% @post.comments.includes([:author]).each do |comment| %>
           <%= render 'comment', comment: comment %>
         <% end %>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,14 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  # config.after_initialize do
+  #   Bullet.enable        = true
+  #   Bullet.bullet_logger = true
+  #   Bullet.raise         = true # raise an error if n+1 query occurs
+  # end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -10,6 +10,6 @@ require 'rails_helper'
 #     end
 #   end
 # end
-RSpec.describe CommentsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe CommentsHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -10,6 +10,6 @@ require 'rails_helper'
 #     end
 #   end
 # end
-RSpec.describe LikesHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe LikesHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -9,7 +9,7 @@ require 'rails_helper'
 #       expect(helper.concat_strings("this","that")).to eq("this that")
 #     end
 #   end
+#  end
+# RSpec.describe PostsHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
 # end
-RSpec.describe PostsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -10,6 +10,6 @@ require 'rails_helper'
 #     end
 #   end
 # end
-RSpec.describe UserHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe UserHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,7 +46,6 @@ RSpec.configure do |config|
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
-  
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
@@ -59,7 +58,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :truncation
   end
 
-   # This block must be here, do not combine with the other `before(:each)` block.
+  # This block must be here, do not combine with the other `before(:each)` block.
   # This makes it so Capybara can see the database.
   config.before(:each) do
     DatabaseCleaner.start

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,10 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+# Setup Capybara
+require 'capybara/rails' # For Rails app
+require 'capybara/rspec'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -41,6 +45,29 @@ RSpec.configure do |config|
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
+
+  
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+   # This block must be here, do not combine with the other `before(:each)` block.
+  # This makes it so Capybara can see the database.
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/comments_request_spec.rb
+++ b/spec/requests/comments_request_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe 'Comments', type: :request do
-  describe 'GET /new' do
-    it 'returns http success' do
-      get '/comments/new'
-      expect(response).to have_http_status(:success)
-    end
-  end
-end
+# RSpec.describe 'Comments', type: :request do
+#   describe 'GET /new' do
+#     it 'returns http success' do
+#       get '/comments/new'
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+# end

--- a/spec/requests/likes_request_spec.rb
+++ b/spec/requests/likes_request_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'Likes', type: :request do
-  describe 'GET /new' do
-    it 'returns http success' do
-      get '/likes/new'
-      expect(response).to have_http_status(:success)
-    end
-  end
-end
+# RSpec.describe 'Likes', type: :request do
+#   describe 'GET /new' do
+#     it 'returns http success' do
+#       get '/likes/new'
+#       expect(response).to have_http_status(:success)
+#     end
+#   end
+# end

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -1,39 +1,39 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'Posts', type: :request do
-  describe 'GET /index' do
-    before do
-      get '/users/:user_id/posts/'
-    end
+# RSpec.describe 'Posts', type: :request do
+#   describe 'GET /index' do
+#     before do
+#       get '/users/:user_id/posts/'
+#     end
 
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
-    end
+#     it 'returns http success' do
+#       expect(response).to have_http_status(:success)
+#     end
 
-    it 'should render index' do
-      expect(response).to render_template(:index)
-    end
+#     it 'should render index' do
+#       expect(response).to render_template(:index)
+#     end
 
-    it 'should include correct placeholder' do
-      expect(response.body).to include("Here are ALL Posts for a given user you are in '/users/user_id/posts")
-    end
-  end
+#     it 'should include correct placeholder' do
+#       expect(response.body).to include("Here are ALL Posts for a given user you are in '/users/user_id/posts")
+#     end
+#   end
 
-  describe 'GET /show' do
-    before do
-      get '/users/:user_id/posts/:id'
-    end
+#   describe 'GET /show' do
+#     before do
+#       get '/users/:user_id/posts/:id'
+#     end
 
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
-    end
+#     it 'returns http success' do
+#       expect(response).to have_http_status(:success)
+#     end
 
-    it 'should render show' do
-      expect(response).to render_template(:show)
-    end
+#     it 'should render show' do
+#       expect(response).to render_template(:show)
+#     end
 
-    it 'should include correct placeholder' do
-      expect(response.body).to include("Here is a single Post for a given user you are in '/users/user_id/posts/id")
-    end
-  end
-end
+#     it 'should include correct placeholder' do
+#       expect(response.body).to include("Here is a single Post for a given user you are in '/users/user_id/posts/id")
+#     end
+#   end
+# end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,39 +1,39 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'Users', type: :request do
-  describe 'GET /index' do
-    before do
-      get '/users/'
-    end
+# RSpec.describe 'Users', type: :request do
+#   describe 'GET /index' do
+#     before do
+#       get '/users/'
+#     end
 
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
-    end
+#     it 'returns http success' do
+#       expect(response).to have_http_status(:success)
+#     end
 
-    it 'should render index' do
-      expect(response).to render_template(:index)
-    end
+#     it 'should render index' do
+#       expect(response).to render_template(:index)
+#     end
 
-    it 'should include correct placeholder' do
-      expect(response.body).to include("Here is a All Post for users you are in '/users'")
-    end
-  end
+#     it 'should include correct placeholder' do
+#       expect(response.body).to include("Here is a All Post for users you are in '/users'")
+#     end
+#   end
 
-  describe 'GET /show' do
-    before do
-      get '/users/:id'
-    end
+#   describe 'GET /show' do
+#     before do
+#       get '/users/:id'
+#     end
 
-    it 'returns http success' do
-      expect(response).to have_http_status(:success)
-    end
+#     it 'returns http success' do
+#       expect(response).to have_http_status(:success)
+#     end
 
-    it 'should render show' do
-      expect(response).to render_template(:show)
-    end
+#     it 'should render show' do
+#       expect(response).to render_template(:show)
+#     end
 
-    it 'should include correct placeholder' do
-      expect(response.body).to include("Here is a single Post for a given user you are in '/users/user_id")
-    end
-  end
-end
+#     it 'should include correct placeholder' do
+#       expect(response.body).to include("Here is a single Post for a given user you are in '/users/user_id")
+#     end
+#   end
+# end

--- a/spec/views/comments/new.html.erb_spec.rb
+++ b/spec/views/comments/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'comments/new.html.erb', type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe 'comments/new.html.erb', type: :view do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/views/likes/new.html.erb_spec.rb
+++ b/spec/views/likes/new.html.erb_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'likes/new.html.erb', type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe 'likes/new.html.erb', type: :view do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/views/posts/index.html.erb_spec.rb
+++ b/spec/views/posts/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'posts/index.html.erb', type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe 'posts/index.html.erb', type: :view do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/views/posts/index.html.erb_spec.rb
+++ b/spec/views/posts/index.html.erb_spec.rb
@@ -1,43 +1,47 @@
 require 'rails_helper'
 
-RSpec.describe Post, type: :feature do 
-    subject { User.new(name: 'Apple',posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
-    before { subject.save }  
-    
-    before(:each) do
-    first_post = Post.create(author_id:subject.id , title: 'Hello!, one', text: 'This is my first post',comment_counter: 0, likes_counter: 0)
-    second_post = Post.create(author_id:subject.id, title: 'Hello!!, two', text: 'This is my second post',comment_counter: 0, likes_counter: 0)
-    third_post = Post.create(author_id:subject.id, title: 'Hello!!!, three', text: 'This is my third post',comment_counter: 0, likes_counter: 0)
-    fourth_post = Post.create(author_id:subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post',comment_counter: 0, likes_counter: 0)
+RSpec.describe Post, type: :feature do
+  subject { User.new(name: 'Apple', posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+  before { subject.save }
 
-    comment1 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 1st comment on the last post')
-    comment2 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 2nd comment on the last post')
-    comment3 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 3rd comment on the last post')
+  before(:each) do
+    Post.create(author_id: subject.id, title: 'Hello!, one', text: 'This is my first post',
+                comment_counter: 0, likes_counter: 0)
+    Post.create(author_id: subject.id, title: 'Hello!!, two', text: 'This is my second post',
+                comment_counter: 0, likes_counter: 0)
+    Post.create(author_id: subject.id, title: 'Hello!!!, three', text: 'This is my third post',
+                comment_counter: 0, likes_counter: 0)
+    fourth_post = Post.create(author_id: subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post',
+                              comment_counter: 0, likes_counter: 0)
+
+    Comment.create(post_id: fourth_post.id, author_id: subject.id, text: 'This is the 1st comment on the last post')
+    Comment.create(post_id: fourth_post.id, author_id: subject.id, text: 'This is the 2nd comment on the last post')
+    Comment.create(post_id: fourth_post.id, author_id: subject.id, text: 'This is the 3rd comment on the last post')
 
     visit(user_posts_path(subject.id))
   end
 
   it 'Display all posts for a user' do
-        expect(page).to have_content('Hello!')
-        expect(page).to have_content('Hello!!')
-        expect(page).to have_content('Hello!!!')
-        expect(page).to have_content('Hello!!!!')    
+    expect(page).to have_content('Hello!')
+    expect(page).to have_content('Hello!!')
+    expect(page).to have_content('Hello!!!')
+    expect(page).to have_content('Hello!!!!')
   end
-  
+
   it 'Display all comments for a user' do
     expect(page).to have_content('This is the 1st comment on the last post')
     expect(page).to have_content('This is the 2nd comment on the last post')
     expect(page).to have_content('This is the 3rd comment on the last post')
   end
-  
+
   it 'Display the name of user in index page of posts' do
     expect(subject.name).to have_content('Apple')
   end
- 
+
   it 'Display the post count of user in index page of posts' do
     expect(page).to have_content('Number of posts: 4')
   end
-  
+
   it 'Display the bio of user in index page of posts' do
     expect(subject.bio).to have_content('Teacher from England.')
   end
@@ -53,6 +57,6 @@ RSpec.describe Post, type: :feature do
 
   it 'Renderning to a certain post' do
     click_link('Hello!!!!')
-    expect(current_path).to eq(user_post_path(subject.id,32))
+    expect(current_path).to eq(user_post_path(subject.id, 32))
   end
 end

--- a/spec/views/posts/index.html.erb_spec.rb
+++ b/spec/views/posts/index.html.erb_spec.rb
@@ -1,5 +1,58 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe 'posts/index.html.erb', type: :view do
-#   pending "add some examples to (or delete) #{__FILE__}"
-# end
+RSpec.describe Post, type: :feature do 
+    subject { User.new(name: 'Apple',posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+    before { subject.save }  
+    
+    before(:each) do
+    first_post = Post.create(author_id:subject.id , title: 'Hello!, one', text: 'This is my first post',comment_counter: 0, likes_counter: 0)
+    second_post = Post.create(author_id:subject.id, title: 'Hello!!, two', text: 'This is my second post',comment_counter: 0, likes_counter: 0)
+    third_post = Post.create(author_id:subject.id, title: 'Hello!!!, three', text: 'This is my third post',comment_counter: 0, likes_counter: 0)
+    fourth_post = Post.create(author_id:subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post',comment_counter: 0, likes_counter: 0)
+
+    comment1 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 1st comment on the last post')
+    comment2 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 2nd comment on the last post')
+    comment3 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 3rd comment on the last post')
+
+    visit(user_posts_path(subject.id))
+  end
+
+  it 'Display all posts for a user' do
+        expect(page).to have_content('Hello!')
+        expect(page).to have_content('Hello!!')
+        expect(page).to have_content('Hello!!!')
+        expect(page).to have_content('Hello!!!!')    
+  end
+  
+  it 'Display all comments for a user' do
+    expect(page).to have_content('This is the 1st comment on the last post')
+    expect(page).to have_content('This is the 2nd comment on the last post')
+    expect(page).to have_content('This is the 3rd comment on the last post')
+  end
+  
+  it 'Display the name of user in index page of posts' do
+    expect(subject.name).to have_content('Apple')
+  end
+ 
+  it 'Display the post count of user in index page of posts' do
+    expect(page).to have_content('Number of posts: 4')
+  end
+  
+  it 'Display the bio of user in index page of posts' do
+    expect(subject.bio).to have_content('Teacher from England.')
+  end
+
+  it 'Display all comments counter for all posts for a user' do
+    expect(page).to have_content('Comments: 3')
+    expect(page).to have_content('Comments: 0')
+  end
+
+  it 'Display all Likes counter for all posts for a user' do
+    expect(page).to have_content('Likes: 0')
+  end
+
+  it 'Renderning to a certain post' do
+    click_link('Hello!!!!')
+    expect(current_path).to eq(user_post_path(subject.id,32))
+  end
+end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -1,26 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe Post, type: :feature do 
-    subject { User.new(name: 'Apple',posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
-    before { subject.save }  
-    
-    before(:each) do
-    fourth_post = Post.create(author_id:subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post',comment_counter: 0, likes_counter: 0)
+RSpec.describe Post, type: :feature do
+  subject { User.new(name: 'Apple', posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+  before { subject.save }
 
-    comment1 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 1st comment on the last post')
-    comment2 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 2nd comment on the last post')
-    comment3 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 3rd comment on the last post')
+  before(:each) do
+    fourth_post = Post.create(author_id: subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post',
+                              comment_counter: 0, likes_counter: 0)
 
-    visit(user_post_path(subject.id,fourth_post.id))
+    Comment.create(post_id: fourth_post.id, author_id: subject.id, text: 'This is the 1st comment on the last post')
+    Comment.create(post_id: fourth_post.id, author_id: subject.id, text: 'This is the 2nd comment on the last post')
+    Comment.create(post_id: fourth_post.id, author_id: subject.id, text: 'This is the 3rd comment on the last post')
+
+    visit(user_post_path(subject.id, fourth_post.id))
   end
-  
+
   it 'Display the text of post for a user' do
-    expect(page).to have_content('This is my fourth post')    
+    expect(page).to have_content('This is my fourth post')
   end
-  
+
   it 'Display the like and Add Comment button in post page' do
-    expect(page).to have_content('Like') 
-    expect(page).to have_content('Add a comment')       
+    expect(page).to have_content('Like')
+    expect(page).to have_content('Add a comment')
   end
 
   it 'Display all comments a post for certain user' do
@@ -36,5 +37,4 @@ RSpec.describe Post, type: :feature do
   it 'Display  Likes counter for the posts for a user' do
     expect(page).to have_content('Likes: 0')
   end
-
 end

--- a/spec/views/posts/show.html.erb_spec.rb
+++ b/spec/views/posts/show.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :feature do 
+    subject { User.new(name: 'Apple',posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+    before { subject.save }  
+    
+    before(:each) do
+    fourth_post = Post.create(author_id:subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post',comment_counter: 0, likes_counter: 0)
+
+    comment1 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 1st comment on the last post')
+    comment2 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 2nd comment on the last post')
+    comment3 = Comment.create(post_id: fourth_post.id, author_id: subject.id,text: 'This is the 3rd comment on the last post')
+
+    visit(user_post_path(subject.id,fourth_post.id))
+  end
+  
+  it 'Display the text of post for a user' do
+    expect(page).to have_content('This is my fourth post')    
+  end
+  
+  it 'Display the like and Add Comment button in post page' do
+    expect(page).to have_content('Like') 
+    expect(page).to have_content('Add a comment')       
+  end
+
+  it 'Display all comments a post for certain user' do
+    expect(page).to have_content('This is the 1st comment on the last post')
+    expect(page).to have_content('This is the 2nd comment on the last post')
+    expect(page).to have_content('This is the 3rd comment on the last post')
+  end
+
+  it 'Display comments counter for the posts for a user' do
+    expect(page).to have_content('Comments: 3')
+  end
+
+  it 'Display  Likes counter for the posts for a user' do
+    expect(page).to have_content('Likes: 0')
+  end
+
+end

--- a/spec/views/user/index.html.erb_spec.rb
+++ b/spec/views/user/index.html.erb_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe 'user/index.html.erb', type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe 'user/index.html.erb', type: :view do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/views/user/index.html.erb_spec.rb
+++ b/spec/views/user/index.html.erb_spec.rb
@@ -1,5 +1,29 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe 'user/index.html.erb', type: :view do
-#   pending "add some examples to (or delete) #{__FILE__}"
-# end
+RSpec.describe User, type: :feature do
+    subject { User.new(name: 'Apple', posts_counter: 2, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+    before { subject.save }  
+
+    before(:each) do
+        visit('/users')
+    end
+
+    it 'Display the name of user in home page' do
+        expect(subject.name).to have_content('Apple')
+    end
+
+    it 'Display the post count of user in home page' do
+        expect(subject.posts_counter).to have_content(2)
+    end
+
+    it 'Display the image of user in home page' do
+         page.has_css?('.img-fluid')
+        end
+
+    it 'Redirect to user show page' do
+        click_link(subject.name)
+        expect(current_path).to eq(user_path(subject.id))
+    end
+end
+
+

--- a/spec/views/user/index.html.erb_spec.rb
+++ b/spec/views/user/index.html.erb_spec.rb
@@ -1,29 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :feature do
-    subject { User.new(name: 'Apple', posts_counter: 2, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
-    before { subject.save }  
+  subject { User.new(name: 'Apple', posts_counter: 2, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+  before { subject.save }
 
-    before(:each) do
-        visit('/users')
-    end
+  before(:each) do
+    visit('/users')
+  end
 
-    it 'Display the name of user in home page' do
-        expect(subject.name).to have_content('Apple')
-    end
+  it 'Display the name of user in home page' do
+    expect(subject.name).to have_content('Apple')
+  end
 
-    it 'Display the post count of user in home page' do
-        expect(subject.posts_counter).to have_content(2)
-    end
+  it 'Display the post count of user in home page' do
+    expect(subject.posts_counter).to have_content(2)
+  end
 
-    it 'Display the image of user in home page' do
-         page.has_css?('.img-fluid')
-        end
+  it 'Display the image of user in home page' do
+    page.has_css?('.img-fluid')
+  end
 
-    it 'Redirect to user show page' do
-        click_link(subject.name)
-        expect(current_path).to eq(user_path(subject.id))
-    end
+  it 'Redirect to user show page' do
+    click_link(subject.name)
+    expect(current_path).to eq(user_path(subject.id))
+  end
 end
-
-

--- a/spec/views/user/show.html.erb_spec.rb
+++ b/spec/views/user/show.html.erb_spec.rb
@@ -1,37 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :feature do
-    subject { User.new(name: 'Apple',posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
-    before { subject.save }  
-    before(:each) do
-    @first_post = Post.create(author_id:subject.id , title: 'Hello!, one', text: 'This is my first post')
-    @second_post = Post.create(author_id:subject.id, title: 'Hello!!, two', text: 'This is my second post')
-    @third_post = Post.create(author_id:subject.id, title: 'Hello!!!, three', text: 'This is my third post')
-    @fourth_post = Post.create(author_id:subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post')
+  subject { User.new(name: 'Apple', posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+  before { subject.save }
+  before(:each) do
+    Post.create(author_id: subject.id, title: 'Hello!, one', text: 'This is my first post')
+    Post.create(author_id: subject.id, title: 'Hello!!, two', text: 'This is my second post')
+    Post.create(author_id: subject.id, title: 'Hello!!!, three', text: 'This is my third post')
+    Post.create(author_id: subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post')
 
     visit(user_path(subject.id))
   end
 
-        it 'Display the name of user in show page' do
-            expect(subject.name).to have_content('Apple')
-        end
-    
-        it 'Display the post count of user in show page' do
-            expect(page).to have_content('Number of posts: 4')
-        end
-        it 'Display the bio of user in show page' do
-            expect(subject.bio).to have_content('Teacher from England.')
-        end
+  it 'Display the name of user in show page' do
+    expect(subject.name).to have_content('Apple')
+  end
 
-        it 'Rendering to  all post ' do
-            click_link('See All Posts')
-            expect(current_path).to eq(user_posts_path(subject.id))
-        end
+  it 'Display the post count of user in show page' do
+    expect(page).to have_content('Number of posts: 4')
+  end
+  it 'Display the bio of user in show page' do
+    expect(subject.bio).to have_content('Teacher from England.')
+  end
 
-        it 'Display post name' do
-            recent_pt=subject.three_recent_posts.each do |p|
-                expect(page).to have_content(p.title)
-            end
-        end
+  it 'Rendering to  all post ' do
+    click_link('See All Posts')
+    expect(current_path).to eq(user_posts_path(subject.id))
+  end
 
+  it 'Display post name' do
+    subject.three_recent_posts.each do |p|
+      expect(page).to have_content(p.title)
+    end
+  end
 end

--- a/spec/views/user/show.html.erb_spec.rb
+++ b/spec/views/user/show.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :feature do
+    subject { User.new(name: 'Apple',posts_counter: 0, photo: 'https://randomuser.me/api/portraits/men/70.jpg', bio: 'Teacher from England.') }
+    before { subject.save }  
+    before(:each) do
+    @first_post = Post.create(author_id:subject.id , title: 'Hello!, one', text: 'This is my first post')
+    @second_post = Post.create(author_id:subject.id, title: 'Hello!!, two', text: 'This is my second post')
+    @third_post = Post.create(author_id:subject.id, title: 'Hello!!!, three', text: 'This is my third post')
+    @fourth_post = Post.create(author_id:subject.id, title: 'Hello!!!!, four', text: 'This is my fourth post')
+
+    visit(user_path(subject.id))
+  end
+
+        it 'Display the name of user in show page' do
+            expect(subject.name).to have_content('Apple')
+        end
+    
+        it 'Display the post count of user in show page' do
+            expect(page).to have_content('Number of posts: 4')
+        end
+        it 'Display the bio of user in show page' do
+            expect(subject.bio).to have_content('Teacher from England.')
+        end
+
+        it 'Rendering to  all post ' do
+            click_link('See All Posts')
+            expect(current_path).to eq(user_posts_path(subject.id))
+        end
+
+        it 'Display post name' do
+            recent_pt=subject.three_recent_posts.each do |p|
+                expect(page).to have_content(p.title)
+            end
+        end
+
+end


### PR DESCRIPTION
The N+1 problem is solved when fetching all posts and their comments for a user. This is the corresponding wireframe - view: blog all user posts

Integration specs:-

- Use Capybara to write integration tests for each view in project.

User index page:

 - I can see the username of all other users.
 - I can see the profile picture for each user.
 - I can see the number of posts each user has written.
 - When I click on a user, I am redirected to that user's show page.

User show page:

 - I can see the user's profile picture.
 - I can see the user's username.
 - I can see the number of posts the user has written.
 - I can see the user's bio.
 - I can see the user's first 3 posts.
 - I can see a button that lets me view all of a user's posts.
 - When I click a user's post, it redirects me to that post's show page. 
 - When I click to see all posts, it redirects me to the user's post's index page.

User post index page:

   - I can see the user's profile picture.
   - I can see the user's username.
   - I can see the number of posts the user has written.
   - I can see a post's title.
   - I can see all comments on a post.
   - I can see how many comments a post has.
   - I can see how many likes a post has.
   - When I click on a post, it redirects me to that post's show page.
 
 User Post show page:

   - I can see the post's title.
   - I can see how many comments it has. 
   - I can see how many likes it has.
   - I can see the post body.
   - I can see the comment each commentor left.
   